### PR TITLE
Demo Travis CI build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+
+os: 
+  - linux
+  - osx
+
+branches:
+  only: 
+    - main
+
+go:
+- 1.15.x
+
+env:
+  - GO111MODULE=on
+
+before_install:
+  - go mod tidy
+
+script:
+  - make build
+  - make cli

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ make cli
 
 ## GitHub Actions
 [Demo workflow](./github/workflows/github-actions-demo.yaml) that builds the Go application server and CLI.
+
+## Travis CI
+[Demo build config](./travis.yml) that builds the Go application server and CLI on linux and OS X.
+
+**Note:** Always run your Travis CI configuration through the [Travis CI Build Config Explorer](https://config.travis-ci.com/explore)


### PR DESCRIPTION
## Summary
- Basic Travis CI build for building the Go application server and CLI
- Runs the build on linux and OS X
- Add travis build link in the README